### PR TITLE
fix: Complementa texto do tema (no MacOS)

### DIFF
--- a/docs/ambiente/02-estudar-swift-sem-macos.md
+++ b/docs/ambiente/02-estudar-swift-sem-macos.md
@@ -1,11 +1,26 @@
 # Não tenho um MacOS, consigo estudar Swift?
 
-Uma boa e uma má notícia para você: A boa é que sim, você consegue estudar a **linguagem Swift** sem um MacOS, visto que ela é open source e pode ser compilada via terminal ou até mesmo pode ser executada em um editor de código online, como por exemplo o [Replit](https://replit.com/).
+Uma boa e uma má notícia para você: 
 
-A má notícia é que você consegue aprender apenas a linguagem mas não colocar em prática através de projetos envolvendo desenvolvimento iOS. Em outras palavras, você não consegue desenvolver um aplicativo, porque para isso necessita da IDE XCode, como mencionamos no tópico anterior.
+✅ A boa é que sim, você consegue estudar a **linguagem Swift** sem um MacOS, visto que ela é open source e pode ser compilada via terminal ou até mesmo pode ser executada em um editor de código online. 
 
-Caso você queira realmente ingressar no desenvolvimento iOS será necessário investir em uma máquina MacOS. Existem algumas soluções que podem funcionar a curto prazo, como o caso de alugar uma máquina na nuvem (Mac In Cloud) ou até mesmo tentar um Hackintosh, embora este último seja mais arriscado. 
+❌ A má notícia é que você consegue aprender apenas a linguagem, mas não colocar em prática através de projetos envolvendo desenvolvimento iOS. 
 
-Atualmente, você também consegue construir um aplicativo através de um outro aplicativo fornecido pela Apple chamado de "Swift Playgrounds". Esse aplicativo está disponível para MacOS e iPadOS, sendo possível criar um aplicativo através de um iPad.
+Em outras palavras, você não consegue desenvolver um aplicativo, porque para isso necessita da IDE [XCode](https://developer.apple.com/xcode/), como mencionamos no tópico anterior.
+
+#### Alternativas para Estudo e Desenvolvimento sem um MacOS:
+
+1. **Compiladores e Ferramentas Online**:
+   - **[Replit](https://replit.com/)**: Uma plataforma online que suporta a execução de código Swift, permitindo que você escreva, compile e execute programas Swift sem a necessidade de um sistema MacOS.
+   - **[Swift Playgrounds](https://developer.apple.com/swift-playgrounds/)**: Disponível para iPadOS e MacOS, é uma ótima ferramenta para iniciantes, oferecendo um ambiente interativo para aprender Swift e programar pequenos projetos.
+
+2. **Máquinas Virtuais e Ambientes na Nuvem**:
+   - **[Mac In Cloud](https://www.macincloud.com/)**: Serviços de aluguel de máquinas Mac na nuvem. Isso permite que você tenha acesso a um ambiente MacOS completo, incluindo o XCode, para desenvolver e testar aplicativos iOS sem precisar comprar um hardware Apple.
+   - **[Hackintosh](https://hackintosh.com/)**: Embora arriscado e não oficialmente suportado pela Apple, a construção de um Hackintosh pode ser uma solução temporária para instalar MacOS em hardware não-Apple. Isso permite acesso a todas as ferramentas de desenvolvimento necessárias, incluindo o XCode.
+
+3. **Desenvolvimento Cross-Plataforma**:
+   - **[VS Code com Extensão Swift](https://www.swift.org/blog/vscode-extension/)**: A extensão do Swift para Visual Studio Code permite desenvolvimento em Swift em várias plataformas, incluindo Linux e Windows. Esta extensão facilita a escrita de código Swift e oferece suporte para debugging e integração com outras ferramentas.
+
+Caso você queira realmente ingressar no desenvolvimento iOS para criar **Aplicações** e **Apps** em ambientes IOS, será necessário investir em uma máquina MacOS. Existem algumas soluções mencionados acima que podem funcionar a curto prazo, como o caso de alugar uma máquina na nuvem (Mac In Cloud) ou até mesmo tentar um Hackintosh, embora este último seja mais arriscado. 
 
 Ir para a próxima página: [03 - Conhecendo o Playground](03-conhecendo-playgrounds.md)


### PR DESCRIPTION
Esta PR detalha um pouco mais sobre o tema de não ter um dispositivo MacOS para trabalhar com a linguagem, visto que a maioria dos usuários que consome e irá consumir este repositório pode não ter um ambiente IOS necessário. 

O texto trás um detalhamento sobre as alternativas e links de referência mais clara, de forma que o tema não seja uma barreira de entrada. Fique a vontade para modificar a sua maneira, caso seja necessário.

@giovannamoeller 