### PR TITLE
fix(docs): corrigir erros ortográficos e exemplo de código

### DIFF
--- a/docs/linguagem/02-tipos.md
+++ b/docs/linguagem/02-tipos.md
@@ -22,8 +22,8 @@ var adulto = true
 
 Strings são um conjunto de caracteres. No Swift, possuímos ambos os tipos: `Character` e `String`.
 ```swift
-    let caractereA: Character = "a" // se não especificar que é um character, o Swift entenderá que é uma string
-    let nome: String = "Giovanna"
+let caractereA: Character = "a" // se não especificar que é um character, o Swift entenderá que é uma string
+let nome: String = "Giovanna"
 ```
 
 Para concatenar duas ou mais strings, podemos fazer de duas maneiras:

--- a/docs/linguagem/09-sets.md
+++ b/docs/linguagem/09-sets.md
@@ -1,6 +1,6 @@
 # Sets
 
-Sets são muito parecidos com arrays, também são coleç˜oes de dados em formato de lista, representados com o uso de colchetes [] e com dados do mesmo tipo.
+Sets são muito parecidos com arrays, também são coleções de dados em formato de lista, representados com o uso de colchetes [] e com dados do mesmo tipo.
 
 Porém, as diferenças entre arrays e sets são:
 - Enquanto é permitido a repetição de um mesmo valor no array (ele pode aparecer múltiplas vezes), nos sets isso não acontece: um valor aparece uma única vez. 

--- a/docs/linguagem/13-iterando-colecoes.md
+++ b/docs/linguagem/13-iterando-colecoes.md
@@ -10,7 +10,7 @@ Vamos ver alguns métodos abaixo. Todos utilizam o conceito de `closure`, passan
 
 ## 1. ForEach
 
-O método `forEach` realiza um loop entre os elementos de uma coleção e perfrorma alguma operação entre eles:
+O método `forEach` realiza um loop entre os elementos de uma coleção e performa alguma operação entre eles:
 
 ```swift
 let valores = [1, 4, 8, 10, 15, 16]

--- a/docs/linguagem/18-propriedades.md
+++ b/docs/linguagem/18-propriedades.md
@@ -121,7 +121,7 @@ Lembrando que `get` e `set` são aplicados somente em propriedades computadas.
 
 ## Propriedades estáticas
 
-Propriedades estáticas são propriedades que pertencem a clsse/struct, e não a sua instância. Elas são definidas pela palavra-chave `static`.
+Propriedades estáticas são propriedades que pertencem a classe/struct, e não a sua instância. Elas são definidas pela palavra-chave `static`.
 
 Veja um exemplo:
 

--- a/docs/linguagem/20-enumeracoes.md
+++ b/docs/linguagem/20-enumeracoes.md
@@ -9,10 +9,10 @@ A sua função pode ser escrita dessa maneira:
 ```swift
 func checaSemaforo(estado: String) {
     switch estado {
-    case "verde": print("Pode seguir!")
-    case "vermelho": print("Fique parado!")
-    case "amarelo": print("Atenção!")
-    default: break
+        case "verde": print("Pode seguir!")
+        case "vermelho": print("Fique parado!")
+        case "amarelo": print("Atenção!")
+        default: break
     }
 }
 
@@ -42,10 +42,10 @@ Agora, não temos mais como errar na hora da escrita, pois temos casos únicos e
 ```swift 
 func checaSemaforo(estado: Semaforo) {
     switch estado {
-    case .verde: print("Pode seguir!")
-    case .vermelho: print("Fique parado!")
-    case .amarelo: print("Atenção!")
-    default: break
+        case .verde: print("Pode seguir!")
+        case .vermelho: print("Fique parado!")
+        case .amarelo: print("Atenção!")
+        default: break
     }
 }
 
@@ -191,8 +191,8 @@ func saque(valor: Int) -> ResultadoSaque {
 var saldo = 100
 let resultado = saque(valor: 110)
 switch resultado {
-case .sucesso(let novoValor): print("Seu novo saldo é de \(novoValor)")
-case .erro(let mensagem): print(mensagem)
+    case .sucesso(let novoValor): print("Seu novo saldo é de \(novoValor)")
+    case .erro(let mensagem): print(mensagem)
 }
 ```
 
@@ -227,8 +227,8 @@ var nome: String?
 nome = "Giovanna"
 
 switch nome {
-case .none: print("A opcional não possui nenhum valor.")
-case .some(let valor): print("O valor da opcional é \(valor)")
+    case .none: print("A opcional não possui nenhum valor.")
+    case .some(let valor): print("O valor da opcional é \(valor)")
 }
 ```
 

--- a/docs/linguagem/20-enumeracoes.md
+++ b/docs/linguagem/20-enumeracoes.md
@@ -9,10 +9,10 @@ A sua função pode ser escrita dessa maneira:
 ```swift
 func checaSemaforo(estado: String) {
     switch estado {
-        case "verde": print("Pode seguir!")
-        case "vermelho": print("Fique parado!")
-        case "amarelo": print("Atenção!")
-        default: break
+    case "verde": print("Pode seguir!")
+    case "vermelho": print("Fique parado!")
+    case "amarelo": print("Atenção!")
+    default: break
     }
 }
 
@@ -42,10 +42,10 @@ Agora, não temos mais como errar na hora da escrita, pois temos casos únicos e
 ```swift 
 func checaSemaforo(estado: Semaforo) {
     switch estado {
-        case .verde: print("Pode seguir!")
-        case .vermelho: print("Fique parado!")
-        case .amarelo: print("Atenção!")
-        default: break
+    case .verde: print("Pode seguir!")
+    case .vermelho: print("Fique parado!")
+    case .amarelo: print("Atenção!")
+    default: break
     }
 }
 
@@ -191,8 +191,8 @@ func saque(valor: Int) -> ResultadoSaque {
 var saldo = 100
 let resultado = saque(valor: 110)
 switch resultado {
-    case .sucesso(let novoValor): print("Seu novo saldo é de \(novoValor)")
-    case .erro(let mensagem): print(mensagem)
+case .sucesso(let novoValor): print("Seu novo saldo é de \(novoValor)")
+case .erro(let mensagem): print(mensagem)
 }
 ```
 
@@ -227,8 +227,8 @@ var nome: String?
 nome = "Giovanna"
 
 switch nome {
-    case .none: print("A opcional não possui nenhum valor.")
-    case .some(let valor): print("O valor da opcional é \(valor)")
+case .none: print("A opcional não possui nenhum valor.")
+case .some(let valor): print("O valor da opcional é \(valor)")
 }
 ```
 

--- a/docs/linguagem/21-protocolos.md
+++ b/docs/linguagem/21-protocolos.md
@@ -34,7 +34,7 @@ class Carro: Veiculo {
 }
 ```
 
-Veja só: nossa classe `Car` está em conformidade com o protocolo `Veiculo`. Caso a gente especifique que precisa estar em conformidade mas não implementa os métodos necessários, causará um erro na nossa aplicação: "Type 'Car' does not conform to protocol 'Veiculo'".
+Veja só: nossa classe `Carro` está em conformidade com o protocolo `Veiculo`. Caso a gente especifique que precisa estar em conformidade mas não implementa os métodos necessários, causará um erro na nossa aplicação: "Type 'Carro' does not conform to protocol 'Veiculo'".
 
 Um protocolo pode ser adotado por uma classe, structure, enumeration ou até mesmo uma extension.
 


### PR DESCRIPTION
Primeiramente, parabéns pelo material. Obrigado!

Este PR corrige erros de ortografia e ajusta exemplo de código.

- Correção de `perfromma` para `performa` (522a7ae8ab71e9718eb18310b313ac185e1f702c);
- Correção de `clsse` para `classe` (05ed74a15b19e13d1f7d3bdb38a3c9289da3d98b);
- Correção de `car` para `carro` (e7703a22d1e59855190cbaad05d936322a7fa620); *
- Correção de `coleç˜oes` para `coleções` (174c9602c8779c44c6b08607a78b3331f3268636);
- ~Ajuste de indentação nos exemplos de código em "Tipos e Operações" (03bcfdf69b3af53c2642583771debd2a5997b3de);~
- ~Ajuste de indentação nos exemplos de código em "Enumerações" (c195803ef9f00237faf6100fec56459e3f0b32be).~

_* Não se trata de erro ortográfico. A alteração tem mais haver com a coerência e contexto no exemplo em questão._